### PR TITLE
crosshair's chartY will be null when adjusting the height of yAxis if options.yAxis.crosshair.snap === false

### DIFF
--- a/highstock.src.js
+++ b/highstock.src.js
@@ -9663,6 +9663,8 @@
                 }
 
                 if (
+                    // after setting "e = this.cross && this.cross.e", e may still be null when options.yAxis.crosshair.snap === false
+                    !e || 
                     // Disabled in options
                     !this.crosshair ||
                     // Snap


### PR DESCRIPTION
If you set up two yAxis and after deleting one of them you want to revise the height of the remaining yAxis to 100% using chart.yAxis[0].update(), there will be an error message saying : 
-  Uncaught TypeError: Cannot read property 'chartY' of undefined

After tracing source code in highstock.src.js, the key word 'this' within the function "drawCrosshair: function(e, point) "in the line 966 would be "Highcharts.Axis". You can spot the property "cross" when you console.log "Highcharts.Axis" or "this". However, when you console.log(this.cross === null) the result will turn out to be true. Hence this pull request......
